### PR TITLE
Minor error caused by LIQUID_INCLUDE_SUFFIX being defined twice

### DIFF
--- a/Liquid.class.php
+++ b/Liquid.class.php
@@ -57,7 +57,7 @@ defined('LIQUID_INCLUDE_SUFFIX') or define('LIQUID_INCLUDE_SUFFIX', 'liquid');
  * Prefix for include files
  *
  */
-defined('LIQUID_INCLUDE_PREFIX') or define('LIQUID_INCLUDE_SUFFIX', '_');
+defined('LIQUID_INCLUDE_PREFIX') or define('LIQUID_INCLUDE_PREFIX', '_');
 /**
  * Tag start
  *


### PR DESCRIPTION
Just fixing a typo that causes a notice level error if LIQUID_INCLUDE_SUFFIX/PREFIX are not pre-defined by the user.
