### PR TITLE
Duplicated codebase hinders functionality.

### DIFF
--- a/lib/LiquidContext.class.php
+++ b/lib/LiquidContext.class.php
@@ -270,14 +270,6 @@ class LiquidContext
 
         $object = $this->fetch(array_shift($parts));
 
-        if (is_object($object))
-        {
-            if (!method_exists($object, 'toLiquid'))
-                throw new LiquidException("Method 'toLiquid' not exists!");
-
-            $object = $object->toLiquid();
-        }
-
         if (!is_null($object))
         {
             while(count($parts) > 0)


### PR DESCRIPTION
Objects properties were unable to be accessed due to misplaced code.

The chunk of code removed (lines 272..279) rendered the following (308..350) useless in case of an object variable.

Now, I can safely do as follows:

      class Foo 
      {
      	public $bar = "Hello World!";
      }
      $assigns = array('foo' => new Foo);
      print $liquid->render($assigns);

and then access the property in the template with:

      {{ foo.bar }}

Otherwise, it just throwed the LiquidException with message `Method 'toLiquid' not exists!`