### PR TITLE
refactor math filters to permit float variables (as ruby lib does)

### DIFF
--- a/lib/LiquidStandardFilters.class.php
+++ b/lib/LiquidStandardFilters.class.php
@@ -3,7 +3,7 @@
  * A selection of standard filters
  *
  * @package Liquid
- * @copyright Copyright (c) 2011-2012 Harald Hanek, 
+ * @copyright Copyright (c) 2011-2012 Harald Hanek,
  * fork of php-liquid (c) 2006 Mateo Murphy,
  * based on Liquid for Ruby (c) 2006 Tobias Luetke
  * @license http://harrydeluxe.mit-license.org
@@ -246,52 +246,52 @@ class LiquidStandardFilters
     /**
      * addition
      *
-     * @param int $input
-     * @param int $operand
-     * @return int
+     * @param float $input
+     * @param float $operand
+     * @return float
      */
     public static function plus($input, $operand)
     {
-        return (int) $input + (int) $operand;
+        return (float) $input + (float) $operand;
     }
 
 
     /**
      * subtraction
      *
-     * @param int $input
-     * @param int $operand
-     * @return int
+     * @param float $input
+     * @param float $operand
+     * @return float
      */
     public static function minus($input, $operand)
     {
-        return (int) $input - (int) $operand;
+        return (float) $input - (float) $operand;
     }
 
 
     /**
      * multiplication
      *
-     * @param int $input
-     * @param int $operand
-     * @return int
+     * @param float $input
+     * @param float $operand
+     * @return float
      */
     public static function times($input, $operand)
     {
-        return (int) $input * (int) $operand;
+        return (float) $input * (float) $operand;
     }
 
 
     /**
      * division
      *
-     * @param int $input
-     * @param int $operand
-     * @return int
+     * @param float $input
+     * @param float $operand
+     * @return float
      */
     public static function divided_by($input, $operand)
     {
-        return (int) $input / (int) $operand;
+        return (float) $input / (float) $operand;
     }
 
 


### PR DESCRIPTION
## Test template

```
plus = {{ 0.5 | plus: 1 }}
minus = {{ 0.5 | minus: 0.25 }}
times = {{ 0.5 | times: 0.25 }}
divided_by = {{ 0.5 | divided_by: 2 }}
```
## Results in both my fork, and ruby liquid

```
plus = 1.5
minus = 0.25
times = 0.125
divided_by = 0.25
```
