### PR TITLE
Improving for tag parameters(limit, offset, reversed)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"php": ">= 5.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7"
+		"phpunit/phpunit": "<6.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"php": ">= 5.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "*"
+		"phpunit/phpunit": "^5.7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -237,20 +237,20 @@ class Context
 	 * @return mixed
 	 */
 	private function variable($key) {
-		// Support [0] style array indicies
-		if (preg_match("|\[[0-9]+\]|", $key)) {
-			$key = preg_replace("|\[([0-9]+)\]|", ".$1", $key);
+		if (!preg_match_all("/(\[?[a-zA-Z0-9\s_-]+\]?)/", $key, $matches)) {
+			return null;
 		}
-        // Support [var] style array indicies
-        elseif (preg_match("|\[(.*)\]|", $key, $matches)) {
-            $var = $this->fetch($matches[1]);
-            $key = preg_replace("|\[(.*)\]|", "." . $var, $key);
-        }
 
-		$parts = explode(Liquid::get('VARIABLE_ATTRIBUTE_SEPARATOR'), $key);
+		$parts = array();
+		foreach ($matches[1] as $match) {
+			if (preg_match("/\[([a-zA-Z0-9\s_-]+)\]/i", $match, $m)) {
+				array_push($parts, is_numeric($m[1]) ? $m[1] : $this->fetch($m[1]));
+			} else {
+				array_push($parts, $match);
+			}
+		}
 
 		$object = $this->fetch(array_shift($parts));
-
 		if (is_object($object)) {
 			if (method_exists($object, 'toLiquid')) {
 				$object = $object->toLiquid();

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -130,4 +130,26 @@ class Liquid
 		}
 		return $return;
 	}
+
+	/**
+	 * All values in PHP Liquid are truthy except null and false.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return bool
+	 */
+	public static function isTruthy($value) {
+		return !self::isFalsy($value);
+	}
+
+	/**
+	 * The falsy values in PHP Liquid are null and false.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return bool
+	 */
+	public static function isFalsy($value) {
+		return $value === false || $value === null;
+	}
 }

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -269,15 +269,17 @@ class StandardFilters
 	/**
 	 * addition
 	 *
-	 * @param int $input
-	 * @param int $operand
+	 * @param float $input
+	 * @param float $operand
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public static function plus($input, $operand) {
-		return (int)$input + (int)$operand;
-	}	
-	
+		$input = is_numeric($input) ? $input : 0;
+		$operand = is_numeric($operand) ? $operand : 0;
+		return $input + $operand;
+	}
+
 
 	/**
 	 * Prepend a string to another

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -468,6 +468,10 @@ class StandardFilters
 	 * @return array
 	 */
 	public static function split($input, $pattern) {
+		// Unlike PHP explode function, empty string after split filtering is empty array in Liquid.
+		if (!is_string($input) || $input === '') {
+			return array();
+		}
 		return explode($pattern, $input);
 	}
 

--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -78,7 +78,7 @@ class TagFor extends AbstractBlock
 			
 		} else {
 			
-			$syntaxRegexp = new Regexp('/(\w+)\s+in\s+\((\d|'.Liquid::get('ALLOWED_VARIABLE_CHARS').'+)\s*..\s*(\d|'.Liquid::get('ALLOWED_VARIABLE_CHARS').'+)\)/');
+			$syntaxRegexp = new Regexp('/(\w+)\s+in\s+\((\d+|'.Liquid::get('ALLOWED_VARIABLE_CHARS').'+)\s*..\s*(\d+|'.Liquid::get('ALLOWED_VARIABLE_CHARS').'+)\)/');
 			if ($syntaxRegexp->match($markup)) {
 				$this->type = 'digit';
 				$this->variableName = $syntaxRegexp->matches[1];

--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -156,10 +156,10 @@ class TagFor extends AbstractBlock
 						'index0' => $index,
 						'rindex' => $length - $index,
 						'rindex0' => $length - $index - 1,
-						'first' => (int)($index == 0),
-						'last' => (int)($index == $length - 1)
+						'first' => $index == 0,
+						'last' => $index == $length - 1
 					));
-		
+
 					$result .= $this->renderAll($this->nodelist, $context);
 					
 					$index++;
@@ -182,7 +182,7 @@ class TagFor extends AbstractBlock
 				$context->push();
 				$result = '';
 				$index = 0;
-				$length = $end - $start;
+				$length = $end - $start + 1;
 
 				$limit = isset($this->attributes['limit']) ? (int) $context->get($this->attributes['limit']) : -1;
 				$offset = isset($this->attributes['offset']) ? (int) $context->get($this->attributes['offset']) : 0;
@@ -203,8 +203,8 @@ class TagFor extends AbstractBlock
 							'index0' 	=> $index,
 							'rindex'	=> $length - $index,
 							'rindex0'	=> $length - $index - 1,
-							'first'		=> (int)($index == 0),
-							'last'		=> (int)($index == $length - 1)
+							'first'		=> $index == 0,
+							'last'		=> $index == $length - 1
 						));
 
 						$result .= $this->renderAll($this->nodelist, $context);
@@ -232,8 +232,8 @@ class TagFor extends AbstractBlock
 							'index0' 	=> $index,
 							'rindex'	=> $length - $index,
 							'rindex0'	=> $length - $index - 1,
-							'first'		=> (int)($index == 0),
-							'last'		=> (int)($index == $length - 1)
+							'first'		=> $index == 0,
+							'last'		=> $index == $length - 1
 						));
 
 						$result .= $this->renderAll($this->nodelist, $context);

--- a/src/Liquid/Tag/TagIf.php
+++ b/src/Liquid/Tag/TagIf.php
@@ -27,6 +27,13 @@ use Liquid\Regexp;
  *
  *     will return:
  *     YES
+ *     
+ * 0 is truthy
+ *
+ *     {% if 0 %} YES {% else %} NO {% endif %}
+ *
+ *     will return:
+ *     YES
  */
 class TagIf extends Decision
 {
@@ -142,10 +149,9 @@ class TagIf extends Decision
 					// If statement is a single condition
 					$display = $this->interpretCondition($conditions[0]['left'], $conditions[0]['right'], $conditions[0]['operator'], $context);
 				}
-
-				if ($display) {
+				// 0 is truthy
+				if ($display || $display === '0' || $display === 0) {
 					$result = $this->renderAll($block[2], $context);
-
 					break;
 				}
 			}

--- a/src/Liquid/Tag/TagIf.php
+++ b/src/Liquid/Tag/TagIf.php
@@ -150,7 +150,7 @@ class TagIf extends Decision
 					$display = $this->interpretCondition($conditions[0]['left'], $conditions[0]['right'], $conditions[0]['operator'], $context);
 				}
 				// 0 is truthy
-				if ($display || $display === '0' || $display === 0) {
+				if (Liquid::isTruthy($display)) {
 					$result = $this->renderAll($block[2], $context);
 					break;
 				}

--- a/src/Liquid/Tag/TagIf.php
+++ b/src/Liquid/Tag/TagIf.php
@@ -113,7 +113,7 @@ class TagIf extends Decision
 				$logicalRegex->matchAll($block[1]);
 
 				$logicalOperators = $logicalRegex->matches;
-				$logicalOperators = $logicalOperators[1];
+				$logicalOperators = array_merge(array('and'), $logicalOperators[1]);
 				// Extract individual conditions
 				$temp = $logicalRegex->split($block[1]);
 
@@ -134,23 +134,21 @@ class TagIf extends Decision
 						throw new LiquidException("Syntax Error in tag 'if' - Valid syntax: if [condition]");
 					}
 				}
-				if (count($logicalOperators)) {
-					// If statement contains and/or
-					$display = $this->interpretCondition($conditions[0]['left'], $conditions[0]['right'], $conditions[0]['operator'], $context);
-					foreach ($logicalOperators as $k => $logicalOperator) {
-						if ($logicalOperator == 'and') {
-							$display = ($display && $this->interpretCondition($conditions[$k + 1]['left'], $conditions[$k + 1]['right'], $conditions[$k + 1]['operator'], $context));
-						} else {
-							$display = ($display || $this->interpretCondition($conditions[$k + 1]['left'], $conditions[$k + 1]['right'], $conditions[$k + 1]['operator'], $context));
-						}
-					}
 
-				} else {
-					// If statement is a single condition
-					$display = $this->interpretCondition($conditions[0]['left'], $conditions[0]['right'], $conditions[0]['operator'], $context);
+				$boolean = true;
+				$results = array();
+				foreach ($logicalOperators as $k => $logicalOperator) {
+					$r = $this->interpretCondition($conditions[$k]['left'], $conditions[$k]['right'], $conditions[$k]['operator'], $context);
+					if ($logicalOperator == 'and') {
+						$boolean = $boolean && Liquid::isTruthy($r);
+					} else {
+						$results[] = $boolean;
+						$boolean = Liquid::isTruthy($r);
+					}
 				}
-				// 0 is truthy
-				if (Liquid::isTruthy($display)) {
+				$results[] = $boolean;
+
+				if (in_array(true, $results)) {
 					$result = $this->renderAll($block[2], $context);
 					break;
 				}

--- a/src/Liquid/Tag/TagPaginate.php
+++ b/src/Liquid/Tag/TagPaginate.php
@@ -110,9 +110,9 @@ class TagPaginate extends AbstractBlock
         $this->currentOffset = ($this->currentPage - 1) * $this->numberItems;
     	$this->collection = $context->get($this->collectionName);
     	$this->collectionSize = count($this->collection);
-    	$this->totalPages = ceil($this->collectionSize / $this->numberItems);
+    	$this->totalPages = (int) ceil($this->collectionSize / $this->numberItems);
     	$paginatedCollection =  array_slice($this->collection, $this->currentOffset, $this->numberItems);
-    	    	
+
     	// Sets the collection if it's a key of another collection (ie search.results, collection.products, blog.articles)
     	$segments = explode('.', $this->collectionName);
     	if (count($segments) == 2) {

--- a/src/Liquid/Variable.php
+++ b/src/Liquid/Variable.php
@@ -131,6 +131,12 @@ class Variable
 			$output = $context->invoke($filtername, $output, $filterArgValues);
 		}
 
+		if (is_float($output)) {
+			if ($output == (int)$output) {
+				return number_format($output, 1);
+			}
+		}
+
 		return $output;
 	}
 }

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -233,4 +233,19 @@ class ContextTest extends TestCase
 		$context->set('test', 'test');
 		$this->assertEquals('test', $context->get('test'));
 	}
+
+	public function testArray() {
+		$assigns = array('a' => 'b');
+		$this->assertTemplateResult('b', '{{ a }}', $assigns);
+		$assigns = array('a' => array('b' => 'c'));
+		$this->assertTemplateResult('c', '{{ a.b }}', $assigns);
+		$this->assertTemplateResult('c', "{{ a['b'] }}", $assigns);
+		$assigns = array('a' => array('b' => array('c' => 'd')));
+		$this->assertTemplateResult('d', '{{ a.b.c }}', $assigns);
+		$this->assertTemplateResult('d', "{{ a['b'].c }}", $assigns);
+		$this->assertTemplateResult('d', "{{ a.b['c'] }}", $assigns);
+		$this->assertTemplateResult('d', "{{ a['b'].c }}", $assigns);
+		$this->assertTemplateResult('d', "{{ a['b']['c'] }}", $assigns);
+		$this->assertTemplateResult('d', "{% assign b = 'b' %}{{ a[b]['c'] }}", $assigns);
+	}
 }

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -657,10 +657,9 @@ class StandardFiltersTest extends TestCase
 			array(
 				1.5,
 				2.7,
-				3,
+				4.2,
 			),
 		);
-
 		foreach ($data as $item) {
 			$this->assertSame($item[2], StandardFilters::plus($item[0], $item[1]));
 		}
@@ -849,4 +848,11 @@ class StandardFiltersTest extends TestCase
 		$this->context->addFilters(new CanadianMoneyFilter(), 'money');
 		$this->assertEquals(' 1000$ CAD ', $var->render($this->context));
 	}
+
+	public function test_plus() {
+		$this->assertTemplateResult('2', '{{ 1 | plus: 1 }}');
+		$this->assertTemplateResult('2.0', '{{ 1 | plus: 1.0 }}');
+		$this->assertTemplateResult('5', "{{ price | plus: '2' }}", array('price' => 3));
+	}
+
 }

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -566,7 +566,7 @@ class StandardFiltersTest extends TestCase
 		$data = array(
 			array(
 				'',
-				array(0 => ''),
+				array(),
 			),
 			array(
 				'two-one-three',

--- a/tests/Liquid/Tag/TagAssignTest.php
+++ b/tests/Liquid/Tag/TagAssignTest.php
@@ -64,5 +64,7 @@ class TagAssignTest extends TestCase
 
 		$template->parse('{% assign test = var1 | join : "." %}{{ test }}');
 		$this->assertTrue($template->render(array('var1' => array('a', 'b', 'c'))) === 'a.b.c');
+
+		$this->assertTemplateResult("true", "{% assign emptyArray = '' | split: ', ' %}{% if emptyArray %}true{% endif %}");
 	}
 }

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -68,8 +68,8 @@ HERE;
 		$this->assertTemplateResult(' 0  1  2 ', '{%for item in array%} {{forloop.index0}} {%endfor%}', $assigns);
 		$this->assertTemplateResult(' 2  1  0 ', '{%for item in array%} {{forloop.rindex0}} {%endfor%}', $assigns);
 		$this->assertTemplateResult(' 3  2  1 ', '{%for item in array%} {{forloop.rindex}} {%endfor%}', $assigns);
-		$this->assertTemplateResult(' 1  0  0 ', '{%for item in array%} {{forloop.first}} {%endfor%}', $assigns);
-		$this->assertTemplateResult(' 0  0  1 ', '{%for item in array%} {{forloop.last}} {%endfor%}', $assigns);
+		$this->assertTemplateResult(' 1     ', '{%for item in array%} {{forloop.first}} {%endfor%}', $assigns);
+		$this->assertTemplateResult('     1 ', '{%for item in array%} {{forloop.last}} {%endfor%}', $assigns);
 	}
 
 	public function testForAndIf() {

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -193,4 +193,19 @@ XPCTD;
 		$this->assertTemplateResult('54321', '{%for i in arr reversed%}{{i}}{%endfor%}', 
 			array('arr' => array(1,2,3,4,5)));
 	}
+
+	public function test_for_with_variable_range() {
+		$this->assertTemplateResult(' 1  2  3 ', '{%for item in (1..foobar) %} {{item}} {%endfor%}', array("foobar" => 3));
+	}
+
+	public function test_for_with_hash_value_range() {
+		$this->assertTemplateResult(' 1  2  3 ', '{%for item in (1..foobar.value) %} {{item}} {%endfor%}', array("foobar" => array('value' => 3)));
+	}
+
+	public function test_for_else() {
+		$this->assertTemplateResult('+++', '{%for item in array%}+{%else%}-{%endfor%}', array('array' => array(1, 2, 3)));
+		$this->assertTemplateResult('-',   '{%for item in array%}+{%else%}-{%endfor%}', array('array' => array()));
+		$this->assertTemplateResult('-',   '{%for item in array%}+{%else%}-{%endfor%}', array('array' => null));
+	}
+
 }

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -180,4 +180,17 @@ next
 XPCTD;
 		$this->assertTemplateResult($expected, $markup, $assigns);
 	}
+
+	public function testForTagParameters() {
+		$this->assertTemplateResult('12345678910', '{%for i in (1..10)%}{{i}}{%endfor%}');
+		$this->assertTemplateResult('1', '{%for i in (1..10) limit:1%}{{i}}{%endfor%}');
+		$this->assertTemplateResult('45', '{%for i in (1..5) offset:3%}{{i}}{%endfor%}');
+		$this->assertTemplateResult('54321', '{%for i in (1..5) reversed%}{{i}}{%endfor%}');
+		$this->assertTemplateResult('1', '{%for i in arr limit:1%}{{i}}{%endfor%}', 
+			array('arr' => array(1,2,3,4,5)));
+		$this->assertTemplateResult('45', '{%for i in arr offset:3%}{{i}}{%endfor%}', 
+			array('arr' => array(1,2,3,4,5)));
+		$this->assertTemplateResult('54321', '{%for i in arr reversed%}{{i}}{%endfor%}', 
+			array('arr' => array(1,2,3,4,5)));
+	}
 }

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -15,6 +15,103 @@ use Liquid\TestCase;
 
 class TagIfTest extends TestCase
 {
+
+	public function testIf() {
+		$this->assertTemplateResult('  ', ' {% if false %} this text should not go into the output {% endif %} ');
+		$this->assertTemplateResult('  this text should go into the output  ',
+			' {% if true %} this text should go into the output {% endif %} ');
+		$this->assertTemplateResult('  you rock ?', '{% if false %} you suck {% endif %} {% if true %} you rock {% endif %}?');
+	}
+
+	public function testLiteralComparisons() {
+		$this->assertTemplateResult(' NO ', '{% assign v = false %}{% if v %} YES {% else %} NO {% endif %}');
+		$this->assertTemplateResult(' YES ', '{% assign v = nil %}{% if v == nil %} YES {% else %} NO {% endif %}');
+	}
+
+	public function test_if_else() {
+		$this->assertTemplateResult(' YES ', '{% if false %} NO {% else %} YES {% endif %}');
+		$this->assertTemplateResult(' YES ', '{% if true %} YES {% else %} NO {% endif %}');
+		$this->assertTemplateResult(' YES ', '{% if "foo" %} YES {% else %} NO {% endif %}');
+	}
+
+	public function test_if_boolean() {
+		$this->assertTemplateResult(' YES ', '{% if var %} YES {% endif %}', array('var' => true));
+	}
+
+	public function test_if_or() {
+		$this->assertTemplateResult(' YES ', '{% if a or b %} YES {% endif %}', array('a' => true, 'b' => true));
+		$this->assertTemplateResult(' YES ', '{% if a or b %} YES {% endif %}', array('a' => true, 'b' => false));
+		$this->assertTemplateResult(' YES ', '{% if a or b %} YES {% endif %}', array('a' => false, 'b' => true));
+		$this->assertTemplateResult('',      '{% if a or b %} YES {% endif %}', array('a' => false, 'b' => false));
+
+		$this->assertTemplateResult(' YES ', '{% if a or b or c %} YES {% endif %}', array('a' => false, 'b' => false, 'c' => true));
+		$this->assertTemplateResult('',      '{% if a or b or c %} YES {% endif %}', array('a' => false, 'b' => false, 'c' => false));
+	}
+
+	public function test_if_or_with_operators() {
+		$this->assertTemplateResult(' YES ', '{% if a == true or b == true %} YES {% endif %}', array('a' => true, 'b' => true));
+		$this->assertTemplateResult(' YES ', '{% if a == true or b == false %} YES {% endif %}', array('a' => true, 'b' => true));
+		$this->assertTemplateResult('', '{% if a == false or b == false %} YES {% endif %}', array('a' => true, 'b' => true));
+	}
+
+	// public function test_comparison_of_strings_containing_and_or_or() {
+	// 	$awful_markup = "a == 'and' and b == 'or' and c == 'foo and bar' and d == 'bar or baz' and e == 'foo' and foo and bar";
+	// 	$assigns = array('a' => 'and', 'b' => 'or', 'c' => 'foo and bar', 'd' => 'bar or baz', 'e' => 'foo', 'foo' => true, 'bar' => true);
+	// 	$this->assertTemplateResult(' YES ', "{% if {$awful_markup} %} YES {% endif %}", $assigns);
+	// }
+
+	public function test_comparison_of_expressions_starting_with_and_or_or() {
+		$assigns = array('order' => array('items_count' => 0), 'android' => array('name' => 'Roy'));
+		$this->assertTemplateResult('YES', "{% if android.name == 'Roy' %}YES{% endif %}", $assigns);
+		$this->assertTemplateResult('YES', "{% if order.items_count == 0 %}YES{% endif %}", $assigns);
+	}
+
+	public function test_if_and() {
+		$this->assertTemplateResult(' YES ', '{% if true and true %} YES {% endif %}');
+		$this->assertTemplateResult('', '{% if false and true %} YES {% endif %}');
+		$this->assertTemplateResult('', '{% if false and true %} YES {% endif %}');
+	}
+	
+	public function test_hash_miss_generates_false() {
+		$this->assertTemplateResult('', '{% if foo.bar %} NO {% endif %}', array('foo' => array()));
+	}
+
+	public function test_multiple_conditions() {
+		$tpl = "{% if a or b and c %}true{% else %}false{% endif %}";
+		$tests = array(
+			array(true, true, true, 'true'),
+			array(true, true, false, 'true'),
+			array(true, false, true, 'true'),
+			array(true, false, false, 'true'),
+			array(false, true, true, 'true'),
+			array(false, true, false, 'false'),
+			array(false, false, true, 'false'),
+			array(false, false, false, 'false'),
+		);
+		foreach ($tests as $args) {
+			$this->assertTemplateResult($args[3], $tpl, array('a' => $args[0], 'b' => $args[1], 'c' => $args[2]));
+		}
+	}
+
+	public function test_comparisons_on_null() {
+		$this->assertTemplateResult('', '{% if null < 10 %} NO {% endif %}');
+		$this->assertTemplateResult('', '{% if null <= 10 %} NO {% endif %}');
+		$this->assertTemplateResult('', '{% if null >= 10 %} NO {% endif %}');
+		$this->assertTemplateResult('', '{% if null > 10 %} NO {% endif %}');
+
+		$this->assertTemplateResult('', '{% if 10 < null %} NO {% endif %}');
+		$this->assertTemplateResult('', '{% if 10 <= null %} NO {% endif %}');
+		$this->assertTemplateResult('', '{% if 10 >= null %} NO {% endif %}');
+		$this->assertTemplateResult('', '{% if 10 > null %} NO {% endif %}');
+	}
+
+	public function test_else_if() {
+		$this->assertTemplateResult('0', '{% if 0 == 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}');
+		$this->assertTemplateResult('1', '{% if 0 != 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}');
+		$this->assertTemplateResult('2', '{% if 0 != 0 %}0{% elsif 1 != 1%}1{% else %}2{% endif %}');
+		$this->assertTemplateResult('elsif', '{% if false %}if{% elsif true %}elsif{% endif %}');
+	}
+
 	public function testZero() {
 		$this->assertTemplateResult("  true  ", " {% if 0 %} true {% else %} false {% endif %} ");
 	}

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -16,9 +16,19 @@ use Liquid\TestCase;
 class TagIfTest extends TestCase
 {
 	public function testZero() {
-		$text = " {% if 0 %} true {% else %} false {% endif %} ";
+		$this->assertTemplateResult("  true  ", " {% if 0 %} true {% else %} false {% endif %} ");
+	}
+
+	public function testEmptyString() {
+		$text = " {% if emptyString %} true {% else %} false {% endif %} ";
 		$expected = "  true  ";
-		$this->assertTemplateResult($expected, $text);
+		$this->assertTemplateResult($expected, $text, array('emptyString' => ''));
+	}
+
+	public function testEmptyArray() {
+		$text = " {% if emptyArray %} true {% else %} false {% endif %} ";
+		$expected = "  true  ";
+		$this->assertTemplateResult($expected, $text, array('emptyArray' => array()));
 	}
 
 	public function testTrueEqlTrue() {

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -15,6 +15,12 @@ use Liquid\TestCase;
 
 class TagIfTest extends TestCase
 {
+	public function testZero() {
+		$text = " {% if 0 %} true {% else %} false {% endif %} ";
+		$expected = "  true  ";
+		$this->assertTemplateResult($expected, $text);
+	}
+
 	public function testTrueEqlTrue() {
 		$text = " {% if true == true %} true {% else %} false {% endif %} ";
 		$expected = "  true  ";

--- a/tests/Liquid/Tag/TagUnlessTest.php
+++ b/tests/Liquid/Tag/TagUnlessTest.php
@@ -15,6 +15,38 @@ use Liquid\TestCase;
 
 class TagUnlessTest extends TestCase
 {
+
+	public function testUnless() {
+		$this->assertTemplateResult('  ', ' {% unless true %} this text should not go into the output {% endunless %} ');
+		$this->assertTemplateResult('  this text should go into the output  ',
+      ' {% unless false %} this text should go into the output {% endunless %} ');
+    	$this->assertTemplateResult('  you rock ?', 
+    		'{% unless true %} you suck {% endunless %} {% unless false %} you rock {% endunless %}?');
+	}
+
+	public function testUnlessElse() {
+		$this->assertTemplateResult(' YES ', '{% unless true %} NO {% else %} YES {% endunless %}');
+    	$this->assertTemplateResult(' YES ', '{% unless false %} YES {% else %} NO {% endunless %}');
+    	$this->assertTemplateResult(' YES ', '{% unless "foo" %} NO {% else %} YES {% endunless %}');
+	}
+
+	public function testUnlessInLoop() {
+		$this->assertTemplateResult('23', 
+			'{% for i in choices %}{% unless i %}{{ forloop.index }}{% endunless %}{% endfor %}',
+			array('choices' => array(1, null, false)));
+	}
+
+	public function testUnlessElseInLoop() {
+		$this->assertTemplateResult(' TRUE  2  3 ', 
+			'{% for i in choices %}{% unless i %} {{ forloop.index }} {% else %} TRUE {% endunless %}{% endfor %}', 
+			array('choices' => array(1, null, false)));
+	}
+
+	public function testEmpty() {
+		$this->assertTemplateResult(" false ", 
+			"{% assign emptyString = '' %}{% unless emptyString %} true {% else %} false {% endunless %}");
+	}
+
 	public function testTrueEqlTrue() {
 		$text = " {% unless true == true %} true {% else %} false {% endunless %} ";
 		$expected = "  false  ";
@@ -25,5 +57,7 @@ class TagUnlessTest extends TestCase
 		$text = " {% unless true != true %} true {% else %} false {% endunless %} ";
 		$expected = "  true  ";
 		$this->assertTemplateResult($expected, $text);
+		$this->assertTemplateResult(' true ', '{% unless true != true %} true {% else %} false {% endunless %}');
 	}
+
 }


### PR DESCRIPTION
Multi-digit Support

```twig
{% for i in (20..30) %} {{i}} {% endfor %}
```

Improving for tag parameters(limit, offset, reversed)

```twig
{% for i in (1..10) limit:1 %} {{i}} {% endfor %}
{% for i in (1..5) offset:3 %} {{i}} {% endfor %}
{% for i in (1..5) reversed %} {{i}} {% endfor %}
```

All values in Liquid are truthy except nil (null in php) and false. Zero, empty string and empty array are all truthy.

For loop else

```twig
{% for item in array %}+{% else %}-{% endfor %}
```

Use square bracket `[ ]` notation to access a specific item in an array.

```twig
{{ a.b.c }}
{{ a['b'].c }}
{{ a.b['c'] }}
{{ a['b']['c'] }}
{% assign b = 'b' %}{{ a[b]['c'] }}
```

Fixing float variable bug.

```twig
{{ 1 | plus: 1.0 }}  // output  2.0
```
