### PR TITLE
More flexible variable name definitions

### DIFF
--- a/examples/protected/templates/index.tpl
+++ b/examples/protected/templates/index.tpl
@@ -34,7 +34,7 @@ This is a comment block
                     <p>Blogentry has tag: freestyle</p>
                 {% endif %}
 
-            </li>      
+            </li>
           {% endfor %}
         </ul>
         {% endif %}

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -54,7 +54,7 @@ class AbstractBlock extends AbstractTag
 
 			if ($startRegexp->match($token)) {
 				if ($tagRegexp->match($token)) {
-					// If we found the proper block delimitor just end parsing here and let the outer block proceed
+					// If we found the proper block delimiter just end parsing here and let the outer block proceed
 					if ($tagRegexp->matches[1] == $this->blockDelimiter()) {
 						$this->endTag();
 						return;
@@ -143,7 +143,7 @@ class AbstractBlock extends AbstractTag
 			case 'end':
 				throw new LiquidException("'end' is not a valid delimiter for " . $this->blockName() . " tags. Use " . $this->blockDelimiter());
 			default:
-				throw new LiquidException("Unkown tag $tag");
+				throw new LiquidException("Unknown tag $tag");
 		}
 	}
 

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -54,7 +54,7 @@ class Context
 		$this->assigns = array($assigns);
 		$this->registers = $registers;
 		$this->filterbank = new Filterbank($this);
-		// first empty array serves as source for ovverides, e.g. as in TagDecrement
+		// first empty array serves as source for overrides, e.g. as in TagDecrement
 		$this->environments = array(array(), $_SERVER);
 	}
 

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -64,8 +64,8 @@ class Liquid
 		// Variable end.
 		'VARIABLE_END' => '}}',
 
-		// The characters allowed in a variable.
-		'ALLOWED_VARIABLE_CHARS' => '[a-zA-Z_.-]',
+		// Variable name.
+		'VARIABLE_NAME' => '[a-zA-Z_][a-zA-Z_0-9.-]*',
 
 		'QUOTED_STRING' => '"[^"]*"|\'[^\']*\'',
 		'QUOTED_STRING_FILTER_ARGUMENT' => '"[^":]*"|\'[^\':]*\'',
@@ -82,6 +82,10 @@ class Liquid
 	 * @return string
 	 */
 	public static function get($key) {
+		// backward compatibility
+		if ($key === 'ALLOWED_VARIABLE_CHARS') {
+			return substr(self::$config['VARIABLE_NAME'], 0, -1);
+		}
 		if (array_key_exists($key, self::$config)) {
 			return self::$config[$key];
 		} else {
@@ -108,6 +112,11 @@ class Liquid
 	 * @param string $value
 	 */
 	public static function set($key, $value) {
+		// backward compatibility
+		if ($key === 'ALLOWED_VARIABLE_CHARS') {
+			$key = 'VARIABLE_NAME';
+			$value .= '+';
+		}
 		self::$config[$key] = $value;
 	}
 

--- a/src/Liquid/Tag/TagBlock.php
+++ b/src/Liquid/Tag/TagBlock.php
@@ -36,7 +36,7 @@ class TagBlock extends AbstractBlock
 	 * Constructor
 	 *
 	 * @param string $markup
-	 * @param Array $tokens
+	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
 	 * @throws \Liquid\LiquidException

--- a/src/Liquid/Tag/TagCapture.php
+++ b/src/Liquid/Tag/TagCapture.php
@@ -37,7 +37,7 @@ class TagCapture extends AbstractBlock
 	 * Constructor
 	 *
 	 * @param string $markup
-	 * @param Array $tokens
+	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
 	 * @throws \Liquid\LiquidException

--- a/src/Liquid/Tag/TagCase.php
+++ b/src/Liquid/Tag/TagCase.php
@@ -112,7 +112,7 @@ class TagCase extends Decision
 				break;
 
 			case 'else':
-				// push the last nodelist onto the stack and prepare to recieve the else nodes
+				// push the last nodelist onto the stack and prepare to receive the else nodes
 				$this->pushNodelist();
 				$this->right = null;
 				$this->elseNodelist = &$this->nodelist;

--- a/src/Liquid/Tag/TagDecrement.php
+++ b/src/Liquid/Tag/TagDecrement.php
@@ -46,7 +46,7 @@ class TagDecrement extends AbstractTag
 	 * @throws \Liquid\LiquidException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null) {
-		$syntax = new Regexp("/(" . Liquid::get('ALLOWED_VARIABLE_CHARS') . "+)/");
+		$syntax = new Regexp('/(' . Liquid::get('VARIABLE_NAME') . ')/');
 
 		if ($syntax->match($markup)) {
 			$this->toDecrement = $syntax->matches[0];

--- a/src/Liquid/Tag/TagDecrement.php
+++ b/src/Liquid/Tag/TagDecrement.php
@@ -75,7 +75,5 @@ class TagDecrement extends AbstractTag
 
 		// decrement the environment value
 		$context->environments[0][$this->toDecrement]--;
-
-		return '';
 	}
 }

--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -30,7 +30,7 @@ use Liquid\Regexp;
  *	   or
  *
  *	   {%for i in (1..10)%} {{i}} {%endfor%}
- *	   {%for i in (1..variable)%} {{i}} {%endfor%} 
+ *	   {%for i in (1..variable)%} {{i}} {%endfor%}
  *
  */
 class TagFor extends AbstractBlock

--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -84,7 +84,7 @@ class TagFor extends AbstractBlock
 
 		parent::__construct($markup, $tokens, $fileSystem);
 
-		$syntaxRegexp = new Regexp('/(\w+)\s+in\s+(' . Liquid::get('ALLOWED_VARIABLE_CHARS') . '+)/');
+		$syntaxRegexp = new Regexp('/(\w+)\s+in\s+(' . Liquid::get('VARIABLE_NAME') . ')/');
 
 		if ($syntaxRegexp->match($markup)) {
 
@@ -95,7 +95,7 @@ class TagFor extends AbstractBlock
 			
 		} else {
 			
-			$syntaxRegexp = new Regexp('/(\w+)\s+in\s+\((\d+|'.Liquid::get('ALLOWED_VARIABLE_CHARS').'+)\s*..\s*(\d+|'.Liquid::get('ALLOWED_VARIABLE_CHARS').'+)\)/');
+			$syntaxRegexp = new Regexp('/(\w+)\s+in\s+\((\d+|' . Liquid::get('VARIABLE_NAME') . ')\s*\.\.\s*(\d+|' . Liquid::get('VARIABLE_NAME') . ')\)/');
 			if ($syntaxRegexp->match($markup)) {
 				$this->type = 'digit';
 				$this->variableName = $syntaxRegexp->matches[1];

--- a/src/Liquid/Tag/TagIf.php
+++ b/src/Liquid/Tag/TagIf.php
@@ -27,7 +27,7 @@ use Liquid\Regexp;
  *
  *     will return:
  *     YES
- *     
+ *
  * 0 is truthy
  *
  *     {% if 0 %} YES {% else %} NO {% endif %}

--- a/src/Liquid/Tag/TagIfchanged.php
+++ b/src/Liquid/Tag/TagIfchanged.php
@@ -13,9 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\AbstractBlock;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
-use Liquid\Regexp;
 
 /**
  * Quickly create a table from a collection
@@ -33,7 +31,7 @@ class TagIfchanged extends AbstractBlock
 	 * Constructor
 	 *
 	 * @param string $markup
-	 * @param Array $tokens
+	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
 	 * @throws \Liquid\LiquidException

--- a/src/Liquid/Tag/TagIncrement.php
+++ b/src/Liquid/Tag/TagIncrement.php
@@ -46,7 +46,7 @@ class TagIncrement extends AbstractTag
 	 * @throws \Liquid\LiquidException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null) {
-		$syntax = new Regexp("/(" . Liquid::get('ALLOWED_VARIABLE_CHARS') . "+)/");
+		$syntax = new Regexp('/(' . Liquid::get('VARIABLE_NAME') . ')/');
 
 		if ($syntax->match($markup)) {
 			$this->toIncrement = $syntax->matches[0];

--- a/src/Liquid/Tag/TagIncrement.php
+++ b/src/Liquid/Tag/TagIncrement.php
@@ -75,7 +75,5 @@ class TagIncrement extends AbstractTag
 
 		// Increment the value
 		$context->environments[0][$this->toIncrement]++;
-
-		return '';
 	}
 }

--- a/src/Liquid/Tag/TagPaginate.php
+++ b/src/Liquid/Tag/TagPaginate.php
@@ -84,7 +84,7 @@ class TagPaginate extends AbstractBlock
 
         parent::__construct($markup, $tokens, $fileSystem);
 
-        $syntax = new Regexp('/(' . Liquid::get('ALLOWED_VARIABLE_CHARS') . '+)\s+by\s+(\w+)/');
+        $syntax = new Regexp('/(' . Liquid::get('VARIABLE_NAME') . ')\s+by\s+(\w+)/');
 
         if ($syntax->match($markup)) {
             $this->collectionName = $syntax->matches[1];

--- a/src/Liquid/Tag/TagPaginate.php
+++ b/src/Liquid/Tag/TagPaginate.php
@@ -19,11 +19,11 @@ use Liquid\FileSystem;
 use Liquid\Regexp;
 
 /**
- * The paginate tag works in conjunction with the for tag to split content into numerous pages. 
+ * The paginate tag works in conjunction with the for tag to split content into numerous pages.
  *
  * Example:
  *
- *	{% paginate collection.products by 5 %}  
+ *	{% paginate collection.products by 5 %}
  * 		{% for product in collection.products %}
  * 			<!--show product details here -->
  * 		{% endfor %}
@@ -34,7 +34,7 @@ use Liquid\Regexp;
 class TagPaginate extends AbstractBlock
 {
 	/**
-     * @var array The collection to paginate
+     * @var string The collection to paginate
      */
     private $collectionName;
 
@@ -42,7 +42,7 @@ class TagPaginate extends AbstractBlock
      * @var array The collection object
      */
     private $collection;
-    
+
     /**
      *
      * @var int The size of the collection
@@ -53,23 +53,23 @@ class TagPaginate extends AbstractBlock
      * @var int The number of items to paginate by
      */
     private $numberItems;
-    
+
     /**
      * @var int The current page
      */
     private $currentPage;
-    
+
     /**
      * @var int The current offset (no of pages times no of items)
      */
     private $currentOffset;
-    
+
     /**
      * @var int Total pages
      */
     private $totalPages;
 
-    
+
     /**
      * Constructor
      *
@@ -81,7 +81,7 @@ class TagPaginate extends AbstractBlock
      *
      */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null) {
-       
+
         parent::__construct($markup, $tokens, $fileSystem);
 
         $syntax = new Regexp('/(' . Liquid::get('ALLOWED_VARIABLE_CHARS') . '+)\s+by\s+(\w+)/');
@@ -93,7 +93,7 @@ class TagPaginate extends AbstractBlock
         } else {
             throw new LiquidException("Syntax Error - Valid syntax: paginate [collection] by [items]");
         }
-        
+
     }
 
     /**
@@ -105,7 +105,7 @@ class TagPaginate extends AbstractBlock
      *
      */
     public function render(Context $context) {
-	    
+
         $this->currentPage = ( is_numeric($context->get('page')) ) ? $context->get('page') : 1;
         $this->currentOffset = ($this->currentPage - 1) * $this->numberItems;
     	$this->collection = $context->get($this->collectionName);
@@ -143,9 +143,9 @@ class TagPaginate extends AbstractBlock
     	$context->set('paginate', $paginate);
     	
         return parent::render($context);
-        
+
     }
-    
+
     /**
      * Returns the current page URL
      *
@@ -155,9 +155,9 @@ class TagPaginate extends AbstractBlock
      *
      */
     public function currentUrl($context) {
-	    
+
 	    $uri = explode('?', $context->get('REQUEST_URI'));
-	    
+
 	    $url = 'http';
 		if ($context->get('HTTPS') == 'on') $url .= 's';
 		$url .= '://' . $context->get('HTTP_HOST') . reset($uri);
@@ -165,5 +165,5 @@ class TagPaginate extends AbstractBlock
 		return $url;
 		
     }
-    
+
 }

--- a/src/Liquid/Tag/TagRaw.php
+++ b/src/Liquid/Tag/TagRaw.php
@@ -43,7 +43,7 @@ class TagRaw extends AbstractBlock
 			$token = array_shift($tokens);
 
 			if ($tagRegexp->match($token)) {
-				// If we found the proper block delimitor just end parsing here and let the outer block proceed
+				// If we found the proper block delimiter just end parsing here and let the outer block proceed
 				if ($tagRegexp->matches[1] == $this->blockDelimiter()) {
 					return;
 				}

--- a/src/Liquid/Tag/TagTablerow.php
+++ b/src/Liquid/Tag/TagTablerow.php
@@ -56,7 +56,7 @@ class TagTablerow extends AbstractBlock
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null) {
 		parent::__construct($markup, $tokens, $fileSystem);
 
-		$syntax = new Regexp("/(\w+)\s+in\s+(" . Liquid::get('ALLOWED_VARIABLE_CHARS') . "+)/");
+		$syntax = new Regexp('/(\w+)\s+in\s+(' . Liquid::get('VARIABLE_NAME') . ')/');
 
 		if ($syntax->match($markup)) {
 			$this->variableName = $syntax->matches[1];

--- a/tests/Liquid/OutputTest.php
+++ b/tests/Liquid/OutputTest.php
@@ -69,16 +69,16 @@ class OutputTest extends TestCase
 
 	public function testVariablePiping() {
 		$text = " {{ car.gm | make_funny }} ";
-		$expectd = " LOL ";
+		$expected = " LOL ";
 
-		$this->assertTemplateResult($expectd, $text, $this->assigns);
+		$this->assertTemplateResult($expected, $text, $this->assigns);
 	}
 
 	public function testVariablePipingWithInput() {
 		$text = " {{ car.gm | cite_funny }} ";
-		$expectd = " LOL: bad ";
+		$expected = " LOL: bad ";
 
-		$this->assertTemplateResult($expectd, $text, $this->assigns);
+		$this->assertTemplateResult($expected, $text, $this->assigns);
 	}
 
 	public function testVariablePipingWithArgs() {

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -261,7 +261,7 @@ class StandardFiltersTest extends TestCase
 	}
 
 	public function testSlice() {
-		// Slize up to the end
+		// Slice up to the end
 		$data = array(
 			array(
 				array(),
@@ -289,7 +289,7 @@ class StandardFiltersTest extends TestCase
 			$this->assertEquals($item[1], StandardFilters::slice($item[0], 2));
 		}
 
-		// Slize a few elements
+		// Slice a few elements
 		$data = array(
 			array(
 				array(),

--- a/tests/Liquid/Tag/TagDecrementTest.php
+++ b/tests/Liquid/Tag/TagDecrementTest.php
@@ -36,4 +36,8 @@ class TagDecrementTest extends TestCase
 	public function testDecrementNestedVariable() {
 		$this->assertTemplateResult(42, '{% for var in vars %}{% decrement var %}{{ var }}{% endfor %}', array('vars' => array(43)));
 	}
+
+	public function testVariableNameContainingNumber() {
+        $this->assertTemplateResult(42, '{% decrement var123 %}{{ var123 }}', array('var123' => 43));
+    }
 }

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -186,11 +186,11 @@ XPCTD;
 		$this->assertTemplateResult('1', '{%for i in (1..10) limit:1%}{{i}}{%endfor%}');
 		$this->assertTemplateResult('45', '{%for i in (1..5) offset:3%}{{i}}{%endfor%}');
 		$this->assertTemplateResult('54321', '{%for i in (1..5) reversed%}{{i}}{%endfor%}');
-		$this->assertTemplateResult('1', '{%for i in arr limit:1%}{{i}}{%endfor%}', 
+		$this->assertTemplateResult('1', '{%for i in arr limit:1%}{{i}}{%endfor%}',
 			array('arr' => array(1,2,3,4,5)));
-		$this->assertTemplateResult('45', '{%for i in arr offset:3%}{{i}}{%endfor%}', 
+		$this->assertTemplateResult('45', '{%for i in arr offset:3%}{{i}}{%endfor%}',
 			array('arr' => array(1,2,3,4,5)));
-		$this->assertTemplateResult('54321', '{%for i in arr reversed%}{{i}}{%endfor%}', 
+		$this->assertTemplateResult('54321', '{%for i in arr reversed%}{{i}}{%endfor%}',
 			array('arr' => array(1,2,3,4,5)));
 	}
 

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -72,6 +72,18 @@ HERE;
 		$this->assertTemplateResult('     1 ', '{%for item in array%} {{forloop.last}} {%endfor%}', $assigns);
 	}
 
+	public function testForHelpersWithOffsetAndLimit() {
+		$assigns = array('array' => array(0, 1, 2, 3, 4));
+
+		$this->assertTemplateResult(' 1/3  2/3  3/3 ', '{%for item in array offset:1 limit:3%} {{forloop.index}}/{{forloop.length}} {%endfor%}', $assigns);
+		$this->assertTemplateResult(' 1  2  3 ', '{%for item in array offset:1 limit:3%} {{forloop.index}} {%endfor%}', $assigns);
+		$this->assertTemplateResult(' 0  1  2 ', '{%for item in array offset:1 limit:3%} {{forloop.index0}} {%endfor%}', $assigns);
+		$this->assertTemplateResult(' 2  1  0 ', '{%for item in array offset:1 limit:3%} {{forloop.rindex0}} {%endfor%}', $assigns);
+		$this->assertTemplateResult(' 3  2  1 ', '{%for item in array offset:1 limit:3%} {{forloop.rindex}} {%endfor%}', $assigns);
+		$this->assertTemplateResult(' 1     ', '{%for item in array offset:1 limit:3%} {{forloop.first}} {%endfor%}', $assigns);
+		$this->assertTemplateResult('     1 ', '{%for item in array offset:1 limit:3%} {{forloop.last}} {%endfor%}', $assigns);
+	}
+
 	public function testForAndIf() {
 		$assigns = array('array' => array(1, 2, 3));
 		$this->assertTemplateResult(' yay     ', '{%for item in array%} {% if forloop.first %}yay{% endif %} {%endfor%}', $assigns);

--- a/tests/Liquid/Tag/TagUnlessTest.php
+++ b/tests/Liquid/Tag/TagUnlessTest.php
@@ -20,7 +20,7 @@ class TagUnlessTest extends TestCase
 		$this->assertTemplateResult('  ', ' {% unless true %} this text should not go into the output {% endunless %} ');
 		$this->assertTemplateResult('  this text should go into the output  ',
       ' {% unless false %} this text should go into the output {% endunless %} ');
-    	$this->assertTemplateResult('  you rock ?', 
+    	$this->assertTemplateResult('  you rock ?',
     		'{% unless true %} you suck {% endunless %} {% unless false %} you rock {% endunless %}?');
 	}
 
@@ -31,19 +31,19 @@ class TagUnlessTest extends TestCase
 	}
 
 	public function testUnlessInLoop() {
-		$this->assertTemplateResult('23', 
+		$this->assertTemplateResult('23',
 			'{% for i in choices %}{% unless i %}{{ forloop.index }}{% endunless %}{% endfor %}',
 			array('choices' => array(1, null, false)));
 	}
 
 	public function testUnlessElseInLoop() {
-		$this->assertTemplateResult(' TRUE  2  3 ', 
-			'{% for i in choices %}{% unless i %} {{ forloop.index }} {% else %} TRUE {% endunless %}{% endfor %}', 
+		$this->assertTemplateResult(' TRUE  2  3 ',
+			'{% for i in choices %}{% unless i %} {{ forloop.index }} {% else %} TRUE {% endunless %}{% endfor %}',
 			array('choices' => array(1, null, false)));
 	}
 
 	public function testEmpty() {
-		$this->assertTemplateResult(" false ", 
+		$this->assertTemplateResult(" false ",
 			"{% assign emptyString = '' %}{% unless emptyString %} true {% else %} false {% endunless %}");
 	}
 

--- a/tests/Liquid/TestCase.php
+++ b/tests/Liquid/TestCase.php
@@ -37,7 +37,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 			'TAG_END' => '%}',
 			'VARIABLE_START' => '{{',
 			'VARIABLE_END' => '}}',
-			'ALLOWED_VARIABLE_CHARS' => '[a-zA-Z_.-]',
+			'VARIABLE_NAME' => '[a-zA-Z_][a-zA-Z0-9_.-]*',
 			'QUOTED_STRING' => '"[^":]*"|\'[^\':]*\'',
 		);
 


### PR DESCRIPTION
Use a complete regex for parsing variable names, not just the individual allowed characters.