### PR TITLE
Context::variable refactored, bugs fixed, tests added

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -317,15 +317,15 @@ class Context
 				continue;
 			}
 
-			// if it's just a regular object, attempt to access a property
-			if (property_exists($object, $nextPartName)) {
-				$object = $object->$nextPartName;
+			// if it's just a regular object, attempt to access a public method
+			if (is_callable(array($object, $nextPartName))) {
+				$object = call_user_func(array($object, $nextPartName));
 				continue;
 			}
 
-			// then try a method
-			if (method_exists($object, $nextPartName)) {
-				$object = call_user_func(array($object, $nextPartName));
+			// then try a property (independent of accessibility)
+			if (property_exists($object, $nextPartName)) {
+				$object = $object->$nextPartName;
 				continue;
 			}
 

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -296,7 +296,7 @@ class Context
 						return null;
 					}
 
-					call_user_func(array($object, Liquid::get('GET_PROPERTY_METHOD')), $nextPartName);
+					$object = call_user_func(array($object, Liquid::get('GET_PROPERTY_METHOD')), $nextPartName);
 				} else {
 					// if it's just a regular object, attempt to access a property
 					if (property_exists($object, $nextPartName)) {

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -251,20 +251,25 @@ class Context
 		}
 
 		$object = $this->fetch(array_shift($parts));
-		if (is_object($object)) {
+		while (count($parts) > 0) {
+			// since we still have a part to consider
+			// and since we can't dig deeper into plain values
+			// it can be thought as if it has a property with a null value
+			if (!is_object($object) && !is_array($object)) {
+				return null;
+			}
+
+			// first try to cast an object to an array or value
 			if (method_exists($object, 'toLiquid')) {
 				$object = $object->toLiquid();
-			} else if (method_exists($object, 'toArray')) {
+			} elseif (method_exists($object, 'toArray')) {
 				$object = $object->toArray();
 			}
-			// we'll cover regular objects later
-		}
 
-		if ($object === null) {
-			return null;
-		}
+			if (is_null($object)) {
+				return null;
+			}
 
-		while (count($parts) > 0) {
 			if ($object instanceof Drop) {
 				$object->setContext($this);
 			}
@@ -277,53 +282,67 @@ class Context
 					return count($object);
 				}
 
-				if (array_key_exists($nextPartName, $object)) {
-					$object = $object[$nextPartName];
-				} else {
+				// no key - no value
+				if (!array_key_exists($nextPartName, $object)) {
 					return null;
 				}
 
-			} elseif (is_object($object)) {
-				if ($object instanceof Drop) {
-					// if the object is a drop, make sure it supports the given method
-					if (!$object->hasKey($nextPartName)) {
-						return null;
-					}
-
-					$object = $object->invokeDrop($nextPartName);
-				} elseif (method_exists($object, Liquid::get('HAS_PROPERTY_METHOD'))) {
-					if (!call_user_func(array($object, Liquid::get('HAS_PROPERTY_METHOD')), $nextPartName)) {
-						return null;
-					}
-
-					$object = call_user_func(array($object, Liquid::get('GET_PROPERTY_METHOD')), $nextPartName);
-				} else {
-					// if it's just a regular object, attempt to access a property
-					if (property_exists($object, $nextPartName)) {
-						$object = $object->$nextPartName;
-					} elseif (method_exists($object, $nextPartName)) {
-						// then try a method
-						$object = call_user_func(array($object, $nextPartName));
-					} else {
-						return null;
-					}
-				}
+				$object = $object[$nextPartName];
+				continue;
 			}
+
+			if (!is_object($object)) {
+				// we got plain value, yet asked to resolve a part
+				// think plain values have a null part with any name
+				return null;
+			}
+
+			if ($object instanceof Drop) {
+				// if the object is a drop, make sure it supports the given method
+				if (!$object->hasKey($nextPartName)) {
+					return null;
+				}
+
+				$object = $object->invokeDrop($nextPartName);
+				continue;
+			}
+
+			// if it has `get` or `field_exists` methods
+			if (method_exists($object, Liquid::get('HAS_PROPERTY_METHOD'))) {
+				if (!call_user_func(array($object, Liquid::get('HAS_PROPERTY_METHOD')), $nextPartName)) {
+					return null;
+				}
+
+				$object = call_user_func(array($object, Liquid::get('GET_PROPERTY_METHOD')), $nextPartName);
+				continue;
+			}
+
+			// if it's just a regular object, attempt to access a property
+			if (property_exists($object, $nextPartName)) {
+				$object = $object->$nextPartName;
+				continue;
+			}
+
+			// then try a method
+			if (method_exists($object, $nextPartName)) {
+				$object = call_user_func(array($object, $nextPartName));
+				continue;
+			}
+
+			// we'll try casting this object in the next iteration
 		}
 
-		// finally, resolve objects to values
-		if (is_object($object) && !($object instanceof \Traversable)) {
-			if (method_exists($object, '__toString')) {
-				$object = (string) $object;
-			} elseif (method_exists($object, 'toLiquid')) {
-				$object = $object->toLiquid();
-			}
+		// finally, resolve an object to a string or a plain value
+		if (method_exists($object, '__toString')) {
+			$object = (string) $object;
+		} elseif (method_exists($object, 'toLiquid')) {
+			$object = $object->toLiquid();
 		}
 
 		// if everything else fails, throw up
 		if (is_object($object) && !($object instanceof \Traversable)) {
 			$class = get_class($object);
-			throw new LiquidException("Value of type $class has no `toLiquid` nor `__toString` method");
+			throw new LiquidException("Value of type $class has no `toLiquid` nor `__toString` methods");
 		}
 
 		return $object;

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -37,6 +37,19 @@ class NoToLiquid {
 	}
 }
 
+class GetSetObject
+{
+	public function field_exists($name) {
+		return $name == 'answer';
+	}
+
+	public function get($prop) {
+		if ($prop == 'answer') {
+			return 42;
+		}
+	}
+}
+
 class HiFilter
 {
 	public function hi($value) {
@@ -114,6 +127,12 @@ class ContextTest extends TestCase
 		$this->assertEquals(42, $this->context->get('test.answer'));
 		$this->assertEquals(1, $this->context->get('test.count'));
 		$this->assertEquals("forty two", $this->context->get('test'));
+	}
+
+	public function testGetSetObject() {
+		$this->context->set('object', new GetSetObject());
+		$this->assertEquals(42, $this->context->get('object.answer'));
+		$this->assertNull($this->context->get('object.invalid'));
 	}
 
 	/**

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -37,6 +37,21 @@ class NoToLiquid {
 	}
 }
 
+class NestedObject
+{
+	public $property;
+	public $value = -1;
+
+	public function toLiquid() {
+		// we intentionally made the value different so
+		// that we could see where it is coming from
+		return array(
+			'property' => $this->property,
+			'value' => 42,
+		);
+	}
+}
+
 class GetSetObject
 {
 	public function field_exists($name) {
@@ -127,6 +142,15 @@ class ContextTest extends TestCase
 		$this->assertEquals(42, $this->context->get('test.answer'));
 		$this->assertEquals(1, $this->context->get('test.count'));
 		$this->assertEquals("forty two", $this->context->get('test'));
+	}
+
+	public function testNestedObject() {
+		$object = new NestedObject();
+		$object->property = new NestedObject();
+		$this->context->set('object', $object);
+		$this->assertEquals(42, $this->context->get('object.value'));
+		$this->assertEquals(42, $this->context->get('object.property.value'));
+		$this->assertNull($this->context->get('object.property.value.invalid'));
 	}
 
 	public function testGetSetObject() {

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -28,6 +28,12 @@ class CentsDrop extends Drop
 class NoToLiquid {
 	public $answer = 42;
 
+	private $name = null;
+
+	public function name() {
+		return 'example';
+	}
+
 	public function count() {
 		return 1;
 	}
@@ -142,6 +148,7 @@ class ContextTest extends TestCase
 		$this->assertEquals(42, $this->context->get('test.answer'));
 		$this->assertEquals(1, $this->context->get('test.count'));
 		$this->assertEquals("forty two", $this->context->get('test'));
+		$this->assertEquals("example", $this->context->get('test.name'));
 	}
 
 	public function testNestedObject() {


### PR DESCRIPTION
- Do not check for `is_object` unless necessarily 
- Call `toLiquid` on every embedded object, not just the first one
- Save value returned from `get` method for objects having `field_exists` method
- Nullify properties of plain values
- First try an object's methods, only then resort to properties that may not be readable

Fixes #40, #42